### PR TITLE
Bump imgui to latest, and minor stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .fips-*
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if (NOT FIPS_IMPORT)
 endif()
 
 if (FIPS_CLANG)
-    set_target_properties(imgui PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable -Wno-type-limits -Wno-missing-field-initializers")
+    set_target_properties(imgui PROPERTIES COMPILE_FLAGS "-Wno-type-limits -Wno-missing-field-initializers")
 elseif(FIPS_GCC)
     set_target_properties(imgui PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable -Wno-type-limits -Wno-missing-field-initializers")
 endif()


### PR DESCRIPTION
Hi, is everyone ok with bumping ImGui to latest? This requires a small code change:

- need to call ImGui::CreateContext() first
- replace ImGui::Shutdown() with ImGui::DestroyContext()

Also 2 minor other changes:
- .vscode/ added to .gitignore
- removed the -Wno-unused-but-set-variable when compiling with clang (this produced an unknown-warning warning on OSX)