### PR TITLE
Fix 'opengl2_example' target name in fips.yaml

### DIFF
--- a/fips.yml
+++ b/fips.yml
@@ -8,7 +8,7 @@ imports:
 run:
     opengl3_example:
         cwd: imgui/examples/
-    opengl_example:
+    opengl2_example:
         cwd: imgui/examples/
     directx11_example:
         cwd: imgui/examples/


### PR DESCRIPTION
Not terribly important, but I saw this while giving `fips` a test run.

The 'opengl_example' target listed in fips.yaml did not exist, the name is 'opengl2_example'.